### PR TITLE
refactor(ffa): begin §6A.2 god-file decomposition — extract pure helpers

### DIFF
--- a/architecture-fitness.json
+++ b/architecture-fitness.json
@@ -2,7 +2,7 @@
   "note": "Architecture ratchet baselines (Phase 3d) — shrink-only, see scripts/architecture-fitness-check.mjs. Each metric cites its plan section/ADR there. Never raise a baseline silently: a raise requires its own commit naming the plan-mandated change (see 2026-07-10 reconciliation: +1 main / +2 LMM / +2 OnlineMP were the §4.4 viewport + §4.6 emit-helper import lines).",
   "capturedAt": "2026-07-14",
   "metrics": {
-    "lines:ffa-p2p-game-state": 4728,
+    "lines:ffa-p2p-game-state": 4709,
     "lines:main": 5817,
     "lines:OdysseyMode": 4924,
     "lines:LocalMultiplayerMode": 4205,

--- a/architecture-fitness.json
+++ b/architecture-fitness.json
@@ -2,7 +2,7 @@
   "note": "Architecture ratchet baselines (Phase 3d) — shrink-only, see scripts/architecture-fitness-check.mjs. Each metric cites its plan section/ADR there. Never raise a baseline silently: a raise requires its own commit naming the plan-mandated change (see 2026-07-10 reconciliation: +1 main / +2 LMM / +2 OnlineMP were the §4.4 viewport + §4.6 emit-helper import lines).",
   "capturedAt": "2026-07-14",
   "metrics": {
-    "lines:ffa-p2p-game-state": 4709,
+    "lines:ffa-p2p-game-state": 4690,
     "lines:main": 5817,
     "lines:OdysseyMode": 4924,
     "lines:LocalMultiplayerMode": 4205,

--- a/src/core/multiplayer/ffa-p2p-game-state.js
+++ b/src/core/multiplayer/ffa-p2p-game-state.js
@@ -93,6 +93,7 @@ import {
     sanitizeFfaNetEventData,
     stableFfaRuleHash,
 } from './ffa/net-diagnostics.js';
+import { garbageBurstKey, drainAllLineBursts } from './ffa/garbage-helpers.js';
 import { seededRandom } from '../../utils/helpers.js';
 
 const JOIN_EVENTS = joinLifecycle.JOIN_LIFECYCLE_EVENTS;
@@ -1737,7 +1738,7 @@ export class FFAGameStateP2P {
 
         // Take lines from queue — DRAIN-ALL to match local (one dump), else one burst.
         const burst = this._garbageDrainAll
-            ? this._drainAllLineBursts(garbageQueue)
+            ? drainAllLineBursts(garbageQueue)
             : garbageQueue.dequeueLineBurst();
 
         if (!burst || burst.length === 0) return;
@@ -2961,13 +2962,13 @@ export class FFAGameStateP2P {
                     let gbEntries = playerData.garbageEntries;
                     if (isLocalPlayer && this._garbageIdempotentEnabled && this._peerConsumedBursts && this._peerConsumedBursts.size) {
                         const hostKeys = new Set();
-                        for (const e of gbEntries) hostKeys.add(this._garbageBurstKey(e));
+                        for (const e of gbEntries) hostKeys.add(garbageBurstKey(e));
                         // Forget consumed keys the host no longer lists — both sides agree they're gone.
                         for (const k of this._peerConsumedBursts) {
                             if (!hostKeys.has(k)) this._peerConsumedBursts.delete(k);
                         }
                         // Don't re-add bursts we already predict-consumed (host is still catching up).
-                        gbEntries = gbEntries.filter((e) => !this._peerConsumedBursts.has(this._garbageBurstKey(e)));
+                        gbEntries = gbEntries.filter((e) => !this._peerConsumedBursts.has(garbageBurstKey(e)));
                     }
                     player.garbageQueue.entries = gbEntries.map((e) => ({
                         type: e.type,
@@ -3725,26 +3726,6 @@ export class FFAGameStateP2P {
     // Stable identity for a garbage line across the peer's predicted consume and the
     // host's serialized queue. attackId is `r{round}-a{seq}` (always non-empty for routed
     // attacks); lineIndex disambiguates lines within one attack. Falls back to attackSeq.
-    _garbageBurstKey(e) {
-        const id = e && (e.attackId || (e.attackSeq != null ? `seq${e.attackSeq}` : 'a'));
-        return `${id}:${e && e.lineIndex != null ? e.lineIndex : 0}`;
-    }
-
-    // DRAIN-ALL (match local): consume EVERY pending line-burst from the queue in one go
-    // (local drainGarbageEntries(queue, true)) and return them as a single combined array.
-    // dequeueLineBurst() bails on a non-'line' head, so this naturally stops at a blind
-    // entry (same boundary as a single dequeue) and can never loop forever.
-    _drainAllLineBursts(garbageQueue) {
-        const all = [];
-        let guard = 0;
-        let burst = garbageQueue.dequeueLineBurst();
-        while (burst && burst.length > 0 && guard++ < 64) {
-            for (const e of burst) all.push(e);
-            burst = garbageQueue.dequeueLineBurst();
-        }
-        return all;
-    }
-
     _insertLocalGarbagePrediction(steamId) {
         if (this.isHost) return; // Host uses _spawnNextPieceForPlayer
 
@@ -3758,14 +3739,14 @@ export class FFAGameStateP2P {
             // Take lines from queue and insert locally — DRAIN-ALL to match local (one
             // dump), else one burst. Both host and peer flip together via the flag.
             const burst = this._garbageDrainAll
-                ? this._drainAllLineBursts(garbageQueue)
+                ? drainAllLineBursts(garbageQueue)
                 : garbageQueue.dequeueLineBurst();
             if (burst && burst.length > 0) {
                 // Idempotent-adopt: remember these bursts so the next host snapshot (which
                 // still lists them until the host consumes them ~½RTT later) does NOT re-add
                 // them in _applySnapshotState → no double-insert / meter rebound.
                 if (this._garbageIdempotentEnabled && this._peerConsumedBursts) {
-                    for (const entry of burst) this._peerConsumedBursts.add(this._garbageBurstKey(entry));
+                    for (const entry of burst) this._peerConsumedBursts.add(garbageBurstKey(entry));
                 }
                 const normalizedBurst = burst.map((entry) => ({
                     ...entry,

--- a/src/core/multiplayer/ffa-p2p-game-state.js
+++ b/src/core/multiplayer/ffa-p2p-game-state.js
@@ -94,6 +94,7 @@ import {
     stableFfaRuleHash,
 } from './ffa/net-diagnostics.js';
 import { garbageBurstKey, drainAllLineBursts } from './ffa/garbage-helpers.js';
+import { checkTopOut, serializeBoardGrid } from './ffa/board-helpers.js';
 import { seededRandom } from '../../utils/helpers.js';
 
 const JOIN_EVENTS = joinLifecycle.JOIN_LIFECYCLE_EVENTS;
@@ -1831,7 +1832,7 @@ export class FFAGameStateP2P {
         });
 
         // Check if player topped out
-        if (this.checkTopOut(player.gameState)) {
+        if (checkTopOut(player.gameState)) {
             this._logGarbage(`💀 ${player.name} topped out!`);
             player.isAlive = false;
             player.gameState.isGameOver = true;
@@ -1929,16 +1930,6 @@ export class FFAGameStateP2P {
         }
 
         return 0;
-    }
-
-    /**
-    * Check if game board has topped out
-    */
-    checkTopOut(gameState) {
-        const HIDDEN_ROWS = 4;
-        // Check if any locked pieces are at or above the spawn line (top of visible area)
-        // Since pieces now spawn at y=HIDDEN_ROWS, having locked pieces there means no room to spawn
-        return gameState.lockedPieces.some((piece) => piece.y <= HIDDEN_ROWS);
     }
 
     /**
@@ -3836,16 +3827,6 @@ export class FFAGameStateP2P {
     }
 
     /**
-     * Strip a board grid to wire form (drop the render-only `id`).
-     */
-    _serializeBoardGrid(grid) {
-        if (!Array.isArray(grid)) return null;
-        return grid.map((row) => (Array.isArray(row)
-            ? row.map((c) => (c ? { color: c.color, type: c.type } : null))
-            : null));
-    }
-
-    /**
      * HOST: broadcast a reliable, self-contained authoritative board for one player
      * the instant its piece settles. Idempotent on the receiver via a per-player
      * monotonic lockSeq; fenced by roundGeneration; carries hostTick so a stale 30Hz
@@ -3866,7 +3847,7 @@ export class FFAGameStateP2P {
             lockSeq: player._lockSeq,
             roundGeneration: this.roundGeneration,
             hostTick: this.hostTick,
-            grid: this._serializeBoardGrid(player.gameState.boardGrid),
+            grid: serializeBoardGrid(player.gameState.boardGrid),
             currentPiece: player.gameState.currentPiece ? { ...player.gameState.currentPiece } : null,
             topOut: !!player.gameState.isGameOver,
         });

--- a/src/core/multiplayer/ffa/board-helpers.js
+++ b/src/core/multiplayer/ffa/board-helpers.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+/**
+ * Pure board/wire helpers extracted from ffa-p2p-game-state.js (plan §6A.2).
+ * No instance state — safe to import in node tests.
+ */
+
+const HIDDEN_ROWS = 4;
+
+/**
+ * True when the board has topped out: any locked piece sits at or above the
+ * spawn line. Pieces spawn at y=HIDDEN_ROWS, so a locked piece there means there
+ * is no room to spawn the next one.
+ * @param {{ lockedPieces?: Array<{ y: number }> }} gameState
+ * @returns {boolean}
+ */
+export function checkTopOut(gameState) {
+    const pieces = gameState && gameState.lockedPieces;
+    if (!Array.isArray(pieces)) return false;
+    return pieces.some((piece) => piece.y <= HIDDEN_ROWS);
+}
+
+/**
+ * Strip a board grid to wire form (drop the render-only `id`), preserving row
+ * structure and null cells.
+ * @param {Array<Array<{ color: unknown, type: unknown }|null>|null>|null|undefined} grid
+ * @returns {Array<Array<{ color: unknown, type: unknown }|null>|null>|null}
+ */
+export function serializeBoardGrid(grid) {
+    if (!Array.isArray(grid)) return null;
+    return grid.map((row) => (Array.isArray(row)
+        ? row.map((c) => (c ? { color: c.color, type: c.type } : null))
+        : null));
+}

--- a/src/core/multiplayer/ffa/garbage-helpers.js
+++ b/src/core/multiplayer/ffa/garbage-helpers.js
@@ -1,0 +1,40 @@
+// @ts-check
+
+/**
+ * Pure garbage-queue helpers extracted from ffa-p2p-game-state.js (plan §6A.2,
+ * the first slice of the future ffa/garbage-system.js). No instance state — safe
+ * to import in node tests. The stateful garbage insertion/counter/prediction
+ * methods remain in the class until they can be moved with dependency injection.
+ */
+
+/**
+ * Stable dedup key for a garbage burst entry: `attackId:lineIndex`. Falls back to
+ * `seq<attackSeq>` then `a` when no attackId, and lineIndex 0 when absent. Used by
+ * the peer's idempotent-adopt set so a host snapshot cannot re-add a burst the peer
+ * already predict-consumed.
+ * @param {{ attackId?: string|number, attackSeq?: number|null, lineIndex?: number|null }|null|undefined} e
+ * @returns {string}
+ */
+export function garbageBurstKey(e) {
+    const id = e && (e.attackId || (e.attackSeq != null ? `seq${e.attackSeq}` : 'a'));
+    return `${id}:${e && e.lineIndex != null ? e.lineIndex : 0}`;
+}
+
+/**
+ * DRAIN-ALL (match local): consume EVERY pending line-burst from the queue in one
+ * go and return them as a single combined array. `dequeueLineBurst()` bails on a
+ * non-'line' head, so this naturally stops at a blind entry (same boundary as a
+ * single dequeue) and can never loop forever (guarded at 64 bursts).
+ * @param {{ dequeueLineBurst: () => Array<any>|null|undefined }} garbageQueue
+ * @returns {Array<any>}
+ */
+export function drainAllLineBursts(garbageQueue) {
+    const all = [];
+    let guard = 0;
+    let burst = garbageQueue.dequeueLineBurst();
+    while (burst && burst.length > 0 && guard++ < 64) {
+        for (const e of burst) all.push(e);
+        burst = garbageQueue.dequeueLineBurst();
+    }
+    return all;
+}

--- a/tests/unit/ffa-garbage-idempotent.test.js
+++ b/tests/unit/ffa-garbage-idempotent.test.js
@@ -17,6 +17,7 @@
 import { describe, it, expect } from 'vitest';
 import { FFAGameStateP2P } from '../../src/core/multiplayer/ffa-p2p-game-state.js';
 import { GarbageQueue } from '../../src/core/garbage.js';
+import { drainAllLineBursts } from '../../src/core/multiplayer/ffa/garbage-helpers.js';
 
 function gbEntry(attackId, lineIndex, extra = {}) {
     return {
@@ -34,7 +35,6 @@ function makePeerStub(consumed = []) {
         _holdStatsEnabled: false,
         _garbageIdempotentEnabled: true,
         _peerConsumedBursts: new Set(consumed),
-        _garbageBurstKey: FFAGameStateP2P.prototype._garbageBurstKey,
         _reconcileLocalPiece: FFAGameStateP2P.prototype._reconcileLocalPiece,
         gamePhase: 'playing',
         winner: null,
@@ -102,7 +102,7 @@ describe('idempotent garbage adoption (peer) — fixes "strange garbage"', () =>
 
     it('drain-all consumes EVERY pending burst in one call (match local "dump"), single-dequeue takes one', () => {
         const lineEntry = (attackId, lineIndex, isLastInBurst) => ({ type: 'line', attackId, lineIndex, holeMask: 1, variant: 'normal', isLastInBurst });
-        const drainAll = FFAGameStateP2P.prototype._drainAllLineBursts; // does not use `this`
+        const drainAll = drainAllLineBursts; // pure helper, extracted to ffa/garbage-helpers.js
         const seed = [
             lineEntry('a1', 0, false), lineEntry('a1', 1, true),
             lineEntry('a2', 0, false), lineEntry('a2', 1, false), lineEntry('a2', 2, true),
@@ -117,10 +117,10 @@ describe('idempotent garbage adoption (peer) — fixes "strange garbage"', () =>
         // drain-all empties the queue and returns all 5 lines in order
         const all = new GarbageQueue();
         all.enqueue(seed.map((e) => ({ ...e })));
-        const drained = drainAll.call({}, all);
+        const drained = drainAll(all);
         expect(drained.map((e) => `${e.attackId}:${e.lineIndex}`)).toEqual(['a1:0', 'a1:1', 'a2:0', 'a2:1', 'a2:2']);
         expect(all.getTotalLines()).toBe(0);
-        expect(drainAll.call({}, new GarbageQueue())).toEqual([]); // empty queue → []
+        expect(drainAll(new GarbageQueue())).toEqual([]); // empty queue → []
     });
 
     it('with ?garbageIdempotent=0 it adopts wholesale (no filtering) — clean revert path', () => {

--- a/ts-ratchet.json
+++ b/ts-ratchet.json
@@ -15,6 +15,7 @@
     "src/core/infinity-simulation-maintenance.js",
     "src/core/infinity-spawn-policy.js",
     "src/core/multiplayer/ffa-p2p-game-state.js",
+    "src/core/multiplayer/ffa/garbage-helpers.js",
     "src/core/multiplayer/ffa/join-handshake.js",
     "src/core/multiplayer/ffa/join-lifecycle.js",
     "src/core/multiplayer/ffa/join-syncpoint.js",

--- a/ts-ratchet.json
+++ b/ts-ratchet.json
@@ -15,6 +15,7 @@
     "src/core/infinity-simulation-maintenance.js",
     "src/core/infinity-spawn-policy.js",
     "src/core/multiplayer/ffa-p2p-game-state.js",
+    "src/core/multiplayer/ffa/board-helpers.js",
     "src/core/multiplayer/ffa/garbage-helpers.js",
     "src/core/multiplayer/ffa/join-handshake.js",
     "src/core/multiplayer/ffa/join-lifecycle.js",


### PR DESCRIPTION
## Summary

The first, deliberately-safe slices of the Phase §6A.2 networking god-file decomposition. Both commits move **genuinely pure, test-covered helpers** out of the 4,728-line `ffa-p2p-game-state.js` into small modules, following the established `net-diagnostics` pure-function extraction pattern. No stateful/behavioral surgery — each is behavior-preserving by construction.

`ffa-p2p-game-state.js`: **4,728 → 4,689 lines** (toward the ≤800 exit target). Two new modules join the `@ts-check` ratchet.

## `fa11719` — extract pure garbage-queue helpers → `ffa/garbage-helpers.js`
- `garbageBurstKey` / `drainAllLineBursts` (no instance state) move verbatim; the 5 internal call sites use the imports; the class methods are removed.
- `ffa-garbage-idempotent.test.js` now imports the helpers directly (it already pinned them as pure — *"does not use `this`"*), strengthening the coverage.

## `f2d0c8a` — extract pure board/wire helpers → `ffa/board-helpers.js`
- `checkTopOut` / `serializeBoardGrid` (no instance state, no external/test callers) move verbatim; the 2 internal call sites use the imports; the class methods are removed. `checkTopOut` gains a defensive non-array guard that can't trigger on a live `gameState`.

## Scope note

The remaining god-file bulk (garbage insertion, roster, snapshot codec, input pipeline, round lifecycle) is deeply stateful and **desync-critical** — the plan names the two-machine drill as its validator. Those slices are intentionally deferred to a session where the multiplayer flow can be driven; this PR sticks to the pure-function extractions that are fully verifiable by the test suite.

## Verification

All gates green: `typecheck`, `ts-ratchet` (45 files), `lint:ci`, `check:boundaries` (826 modules), `architecture-fitness` (ffa ratchet lowered twice), and the full **2,396-test suite** including all 161 MP tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9nwenBMZ2VQfJaUNC8CDC)_