### PR TITLE
refactor(events): §4.6 — route main.js quartet emits through the shared helper

### DIFF
--- a/architecture-fitness.json
+++ b/architecture-fitness.json
@@ -1,9 +1,9 @@
 {
-  "note": "Architecture ratchet baselines (Phase 3d) — shrink-only, see scripts/architecture-fitness-check.mjs. Each metric cites its plan section/ADR there. Never raise a baseline silently: a raise requires its own commit naming the plan-mandated change (see 2026-07-10 reconciliation: +1 main / +2 LMM / +2 OnlineMP were the §4.4 viewport + §4.6 emit-helper import lines).",
+  "note": "Architecture ratchet baselines (Phase 3d) — shrink-only, see scripts/architecture-fitness-check.mjs. Each metric cites its plan section/ADR there. Never raise a baseline silently: a raise requires its own commit naming the plan-mandated change (see 2026-07-10 reconciliation: +1 main / +2 LMM / +2 OnlineMP were the §4.4 viewport + §4.6 emit-helper import lines; 2026-07-14: +1 main for the §4.6 main.js emit-helper import).",
   "capturedAt": "2026-07-14",
   "metrics": {
     "lines:ffa-p2p-game-state": 4690,
-    "lines:main": 5817,
+    "lines:main": 5818,
     "lines:OdysseyMode": 4924,
     "lines:LocalMultiplayerMode": 4205,
     "lines:OnlineMultiplayerMode": 3271,

--- a/src/main.js
+++ b/src/main.js
@@ -54,6 +54,7 @@ import { createBoardScene } from './rendering/phaser/board-scene.js';
 import { createBackgroundScene } from './rendering/phaser/background-scene.js';
 import { createMultiplayerBoardScene } from './rendering/phaser/multiplayer/board-panel.js';
 import { eventBus, EVENTS } from './events/event-bus.js';
+import { emitLineClear, emitCombo, emitPieceLock } from './events/gameplay-events.js';
 import { initViewportBroadcaster } from './utils/viewport.js';
 import { normalizeQuality } from './utils/quality.js';
 import { DisplayManager } from './core/display-manager.js';
@@ -3398,7 +3399,7 @@ class SerenityBlocks {
 
                 // Emit event for theme reactions
                 console.log('[Main] Emitting LINE_CLEAR event, count:', count);
-                eventBus.emit(EVENTS.LINE_CLEAR, { lineCount: count, clearedRows });
+                emitLineClear({ lineCount: count, clearedRows });
             },
             updateBoard: (boardData) => {
                 // Board updates handled in draw
@@ -3438,7 +3439,7 @@ class SerenityBlocks {
 
                 // Emit event for theme reactions
                 console.log('[Main] Emitting COMBO event, comboCount:', comboCount);
-                eventBus.emit(EVENTS.COMBO, { comboCount });
+                emitCombo({ comboCount });
             },
             onPieceLock: (piece) => {
                 const gameState = getState();
@@ -3453,7 +3454,7 @@ class SerenityBlocks {
                 }
 
                 // Emit event for theme reactions
-                eventBus.emit(EVENTS.PIECE_LOCK, { piece });
+                emitPieceLock({ piece });
             },
             updateBackground: (level) => {
                 const settings = this.settingsManager.get();
@@ -4637,7 +4638,7 @@ class SerenityBlocks {
                 );
 
                 // Emit event for theme reactions
-                eventBus.emit(EVENTS.LINE_CLEAR, { lineCount: count, player: playerNum, clearedRows });
+                emitLineClear({ lineCount: count, player: playerNum, clearedRows });
             },
             onGarbageReady: (summary) => {
                 // Convert playerNum to appropriate format based on multiplayerState structure
@@ -4735,7 +4736,7 @@ class SerenityBlocks {
                 }
 
                 // Emit event for theme reactions
-                eventBus.emit(EVENTS.COMBO, { comboCount, player: playerNum });
+                emitCombo({ comboCount, player: playerNum });
             },
             onPieceLock: (piece) => {
                 const settings = this.settingsManager.get();
@@ -4758,7 +4759,7 @@ class SerenityBlocks {
                 multiplayerState?.accumulateHandicap?.(playerNum - 1);
 
                 // Emit event for theme reactions
-                eventBus.emit(EVENTS.PIECE_LOCK, { piece, player: playerNum });
+                emitPieceLock({ piece, player: playerNum });
             },
             updateBackground: (level) => {
                 // Background updates can be shared between players


### PR DESCRIPTION
## Summary

The verifiable half of Phase §4.6: `main.js` was the **last holdout** still emitting the gameplay quartet directly, bypassing the canonical `gameplay-events.js` helpers that the six game modes already use. This routes its 6 sites through the helper, so each event now has **one emit site with one payload shape** — closing the "6-shape problem" §4.6 targets.

## What changed

`src/main.js` — 6 direct `eventBus.emit(EVENTS.…)` calls → the shared helper:

| Site | Before | After |
|---|---|---|
| single-player `onLineClear` | `emit(LINE_CLEAR, {lineCount, clearedRows})` | `emitLineClear(…)` |
| single-player `triggerCombo` | `emit(COMBO, {comboCount})` | `emitCombo(…)` |
| single-player `onPieceLock` | `emit(PIECE_LOCK, {piece})` | `emitPieceLock(…)` |
| local-MP × 3 | same, with `player: playerNum` | the three helpers |

**Behavior-preserving:** the helper normalizes `LINE_CLEAR` to always carry `clearedRows` + `cascadeCount` (consumers already default `cascadeCount` to `1`); `COMBO`/`PIECE_LOCK` payloads are identical; `player` is a preserved common optional. Pinned by `gameplay-event-payloads.test.js`.

## Scope note

This is the emit-site consolidation only. The other §4.6 deliverable — a `StandardGameLoopMode` base class owning pause/resume lifecycle — touches mode lifecycle with runtime surface that isn't safely verifiable in a test-only session, so it's intentionally deferred.

## Baseline note

Raises `lines:main` +1 (5817→5818) for the emit-helper import — the exact sanctioned case the `architecture-fitness.json` note cites (*"§4.6 emit-helper import lines"*). The 6 `// Emit event for theme reactions` comments are kept for their don't-delete-me signal rather than gutted to game the count.

## Verification

All gates green: `typecheck`, `ts-ratchet`, `lint:ci`, `check:boundaries` (826 modules), `architecture-fitness`, the `gameplay-event-payloads` + `event-contract` pins, and the full **2,396-test suite**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9nwenBMZ2VQfJaUNC8CDC)_