### PR TITLE
test(sim): §3b.7 — fast-check metamorphic-determinism property for resolveCascade

### DIFF
--- a/tests/unit/cascade-resolver-property.test.js
+++ b/tests/unit/cascade-resolver-property.test.js
@@ -1,0 +1,90 @@
+/**
+ * Metamorphic determinism + purity property for the pure §5.2 resolveCascade
+ * (remediation plan §3b.7 — the fast-check "metamorphic determinism" property
+ * the plan calls for, applied to the resolver, which is deterministic by
+ * design). Complements cascade-resolver-differential.test.js (resolver-vs-legacy
+ * equivalence) with resolver-vs-ITSELF self-consistency over a fuzzed input
+ * space.
+ *
+ * Two invariants, over bounded random boards (full rows + scattered blocks so
+ * cascades actually fire):
+ *  1. DETERMINISM — the same input resolved twice yields an identical result and
+ *     an identical settled-board digest. A regression that leaks Math.random /
+ *     Date.now / object-identity iteration order into the pure core (the exact
+ *     classes the §3d fitness ratchet bans statically) fails here behaviourally.
+ *  2. PURITY — the resolver owns working copies (clonePieces); the caller's
+ *     lockedPieces array is never mutated.
+ */
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { resolveCascade } from '../../src/core/cascade-resolver.js';
+import { computeBoardDigest } from '../../src/core/demo/demo-state.js';
+import { COLS, ROWS, HIDDEN_ROWS } from '../../src/core/constants.js';
+
+const BOTTOM = ROWS + HIDDEN_ROWS - 1;
+
+// Piece shapes mirror cascade-resolver-differential.test.js's factories.
+const fullRow = (y, id) => ({
+    pieceId: id, color: '#666', type: 'garbage', x: 0, y, shape: [Array(COLS).fill(1)],
+});
+const block = (x, y, id) => ({
+    pieceId: id, color: '#888', type: 'block', x, y, shape: [[1]],
+});
+
+const rowArb = fc.integer({ min: HIDDEN_ROWS, max: BOTTOM });
+const cellArb = fc.record({
+    x: fc.integer({ min: 0, max: COLS - 1 }),
+    y: fc.integer({ min: HIDDEN_ROWS, max: BOTTOM }),
+});
+const contextArb = fc.record({
+    level: fc.integer({ min: 1, max: 20 }),
+    lines: fc.integer({ min: 0, max: 300 }),
+    linesUntilNextLevel: fc.integer({ min: 1, max: 15 }),
+    b2bActive: fc.boolean(),
+});
+
+function buildPieces(fullRows, cells) {
+    const pieces = [];
+    fullRows.forEach((y, i) => pieces.push(fullRow(y, `row-${i}`)));
+    cells.forEach((c, i) => pieces.push(block(c.x, c.y, `blk-${i}`)));
+    return pieces;
+}
+
+function makeContext(c) {
+    return {
+        level: c.level,
+        lines: c.lines,
+        linesUntilNextLevel: c.linesUntilNextLevel,
+        dropInterval: 800,
+        disableLevelProgression: false,
+        b2bActive: c.b2bActive,
+        comboState: { lockFootprint: [], manualColumns: [] },
+    };
+}
+
+describe('resolveCascade — metamorphic determinism & purity (plan §3b.7 / §5.2)', () => {
+    it('resolves deterministically and never mutates its input', () => {
+        fc.assert(
+            fc.property(
+                fc.uniqueArray(rowArb, { maxLength: 6 }),
+                fc.array(cellArb, { maxLength: 24 }),
+                contextArb,
+                (fullRows, cells, ctxRaw) => {
+                    const pieces = buildPieces(fullRows, cells);
+                    const ctx = makeContext(ctxRaw);
+                    const before = JSON.stringify(pieces);
+
+                    const r1 = resolveCascade(pieces, ctx);
+                    // PURITY: the caller's input is untouched.
+                    expect(JSON.stringify(pieces)).toBe(before);
+
+                    // DETERMINISM: identical input → identical result + digest.
+                    const r2 = resolveCascade(pieces, ctx);
+                    expect(JSON.stringify(r1)).toBe(JSON.stringify(r2));
+                    expect(computeBoardDigest(r1.boardAfter)).toBe(computeBoardDigest(r2.boardAfter));
+                },
+            ),
+            { numRuns: 200 },
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Fills the one missing **Phase §3b.7** fast-check property — the plan asked for two (metamorphic determinism + adversarial decoder), but only the adversarial decoder (`binary-decoder-fuzz`) had landed. This adds the metamorphic-determinism half, applied to the pure §5.2 `resolveCascade`.

**Test-only — zero production-code change.**

## The property

Over bounded random boards (full rows + scattered blocks, so cascades actually fire), `resolveCascade`:

1. **Determinism** — resolving the same input twice yields an identical result *and* an identical settled-board digest. This is the **behavioural complement** to the §3d fitness ratchet that *statically* bans `Math.random` / `Date.now` / `performance.now` in the core sim: a regression that leaks nondeterminism — or object-identity iteration order — into the resolver fails here even if it dodges the static check.
2. **Purity** — the resolver owns working copies (`clonePieces`); the caller's `lockedPieces` array is never mutated.

Complements `cascade-resolver-differential.test.js` (resolver-vs-legacy equivalence) with resolver-vs-*itself* self-consistency over a fuzzed input space. Reuses that test's piece-shape factories and `baseContext` for crash-free, valid inputs. 200 runs.

## Verification

New property passes; full suite **2,396 → 2,397** green; `check:boundaries` clean. No `src` change, so typecheck/lint/fitness are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9nwenBMZ2VQfJaUNC8CDC)_