### PR TITLE
Fix duplicate "Serenity Blocks" menu header after skipped intro

### DIFF
--- a/src/ui/intro-animation.js
+++ b/src/ui/intro-animation.js
@@ -1345,6 +1345,20 @@ export class IntroAnimation {
     }
 
     /**
+     * The cinematic intro title has become the live menu logo again. Clear the
+     * terminal `startup-intro-skipped` flag so the CSS keeps hiding the static
+     * DOM `.main-menu-logo`. Without this, the skipped-intro CSS override keeps
+     * the static logo visible while `showBackgroundOnly()` re-creates the
+     * animated title, so the menu renders the "Serenity Blocks" header twice
+     * (repro: skip the intro, enter Local Multiplayer, return to the menu).
+     */
+    _claimMenuLogoIdentity() {
+        if (typeof document !== 'undefined') {
+            document.body.classList.remove('startup-intro-skipped');
+        }
+    }
+
+    /**
      * Show only the background animation with shrunken logo at top
      * (for returning to start modal from gameplay)
      */
@@ -1367,6 +1381,7 @@ export class IntroAnimation {
                     titleContainer.classList.add('shrink-to-logo');
                     this.scheduleMenuLogoLayoutUpdate();
                 }
+                this._claimMenuLogoIdentity();
 
                 // Hide prompt/chromatic if they exist (cleanup from full intro)
                 const prompt = this.container.querySelector('.intro-prompt');
@@ -1449,6 +1464,7 @@ export class IntroAnimation {
 
         // Add to DOM
         document.body.appendChild(this.container);
+        this._claimMenuLogoIdentity();
         this.setupMenuLogoLayoutTracking();
         this.scheduleMenuLogoLayoutUpdate();
         this.syncTitleBounds(performance.now());

--- a/tests/unit/intro-menu-logo-identity.test.js
+++ b/tests/unit/intro-menu-logo-identity.test.js
@@ -1,0 +1,89 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+
+/**
+ * Regression: the main menu showed the "Serenity Blocks" title twice after
+ * skipping the intro and then entering/leaving a mode (e.g. Local Multiplayer).
+ *
+ * When the intro is skipped, `body.startup-intro-skipped` is set and CSS keeps
+ * the static DOM `.main-menu-logo` visible as the menu identity. On return to
+ * the menu, `showBackgroundOnly()` re-creates the animated cinematic title as
+ * the logo — but the stale `startup-intro-skipped` class kept the static logo
+ * visible too, so both rendered at once. `showBackgroundOnly()` must clear that
+ * class whenever the cinematic title becomes the live menu logo again.
+ */
+
+function makeClassList(initial = []) {
+    const set = new Set(initial);
+    return {
+        add: (c) => set.add(c),
+        remove: (c) => set.delete(c),
+        contains: (c) => set.has(c),
+    };
+}
+
+function installFakeDocument(container) {
+    const body = {
+        classList: makeClassList(['startup-intro-skipped']),
+        contains: (node) => node === container,
+    };
+    globalThis.document = { body };
+    return body;
+}
+
+describe('intro menu-logo identity (duplicate header fix)', () => {
+    let introAnimation;
+    const originalDocument = globalThis.document;
+
+    beforeEach(async () => {
+        ({ introAnimation } = await import('../../src/ui/intro-animation.js'));
+    });
+
+    afterEach(() => {
+        globalThis.document = originalDocument;
+        vi.restoreAllMocks();
+    });
+
+    it('clears startup-intro-skipped when reviving the cinematic menu logo', () => {
+        const titleContainer = { classList: makeClassList() };
+        const container = {
+            classList: makeClassList(),
+            style: { display: 'none', removeProperty: () => {} },
+            querySelector: (sel) => (sel === '.intro-title-container' ? titleContainer : null),
+        };
+        const body = installFakeDocument(container);
+
+        introAnimation.container = container;
+        introAnimation.threeRenderer = null;
+        // Stub the render/audio side-effects so we exercise only the DOM/state path.
+        vi.spyOn(introAnimation, 'scheduleMenuLogoLayoutUpdate').mockImplementation(() => {});
+        vi.spyOn(introAnimation, 'setLoadingState').mockImplementation(() => {});
+        vi.spyOn(introAnimation, 'ensureIntroMusic').mockImplementation(() => {});
+        vi.spyOn(introAnimation, 'setRendererPhase').mockImplementation(() => {});
+        vi.spyOn(introAnimation, 'startRenderLoop').mockImplementation(() => {});
+        vi.spyOn(introAnimation, 'installTetrominoPointerListener').mockImplementation(() => {});
+
+        expect(body.classList.contains('startup-intro-skipped')).toBe(true);
+
+        introAnimation.showBackgroundOnly();
+
+        // The cinematic title is live again → static DOM logo must be hidden.
+        expect(body.classList.contains('startup-intro-skipped')).toBe(false);
+        expect(titleContainer.classList.contains('shrink-to-logo')).toBe(true);
+
+        introAnimation.container = null;
+    });
+
+    it('_claimMenuLogoIdentity removes the terminal skip flag', () => {
+        const body = installFakeDocument(null);
+        expect(body.classList.contains('startup-intro-skipped')).toBe(true);
+        introAnimation._claimMenuLogoIdentity();
+        expect(body.classList.contains('startup-intro-skipped')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the main menu showing the **"Serenity Blocks" title twice** after skipping the intro and then entering/leaving a mode (e.g. Local Multiplayer, then back to the menu).

## Root cause

The menu has two title elements that are meant to be mutually exclusive:

1. The static DOM logo — `<h1 class="main-menu-logo">` in `index.html`.
2. The animated cinematic title — an `.intro-title-container` created by `src/ui/intro-animation.js` that shrinks into a logo.

CSS decides which is the menu identity. Normally the cinematic title is the logo and the static one is hidden. **But** when the intro is skipped (user skip or the startup watchdog disposing WebGPU visuals), `body.startup-intro-skipped` is set and a CSS override brings the static DOM logo back as the "stable menu identity."

That class is only ever cleared once, during the first boot. When you enter Local Multiplayer, the mode removes the cinematic intro container; on return, `showBackgroundOnly()` **re-creates** the animated title as the logo — but the stale `startup-intro-skipped` class was still on `<body>`, so the static logo stayed visible too. Both render → two headers.

(Not strictly Local-Multiplayer-specific — any mode return after a skipped intro hits it — but that's the reported path.)

## Fix

`showBackgroundOnly()` now clears `startup-intro-skipped` whenever the cinematic title becomes the live menu logo again (both the revive and fresh-create paths), via a small `_claimMenuLogoIdentity()` helper. Once the animated title is back, the flag no longer reflects reality, so removing it lets CSS hide the static logo — exactly one title shows.

## Changes

- `src/ui/intro-animation.js` — add `_claimMenuLogoIdentity()` and call it where the cinematic intro is (re)established as the menu logo.
- `tests/unit/intro-menu-logo-identity.test.js` — regression test asserting the flag is cleared when the menu logo is re-established.

## Testing

- New regression test passes.
- Existing `startup-animation-reliability` and `intro-tetromino-interactions` suites pass.
- ESLint clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYED438sCi9mE4mpfT1BQu)_