### PR TITLE
Make the startup watchdog terminal so a stalled boot can't hang the ident (R1)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5180,7 +5180,7 @@ async function bootstrap() {
             );
         }
 
-        app = await appInitPromise;
+        app = await Promise.race([appInitPromise, startupPipeline.waitForMenuVisible().then(() => null)]); // stalled init can't hang the ident: the watchdog's degraded MENU_VISIBLE wins the race and yields null (normal/skip boots let init win)
         startupPipeline.markAppReady({
             windowsProfile: desktopRuntimeConfig.windowsProfile,
             safeMode,
@@ -5275,7 +5275,7 @@ async function bootstrap() {
         }
 
         if (!app) {
-            app = await appInitPromise;
+            app = await Promise.race([appInitPromise, startupPipeline.waitForMenuVisible().then(() => null)]); // degraded path: menu already visible → resolves null now instead of re-blocking on the stalled init
         }
         app?.setBootCoordinator?.(desktopBootCoordinator);
         app?.markBootStage?.('core-ready', {

--- a/src/ui/startup-pipeline-controller.js
+++ b/src/ui/startup-pipeline-controller.js
@@ -85,6 +85,7 @@ export function createStartupPipelineController(options = {}) {
                     timeToMenuVisibleMs: Math.round(snapshot.metrics.timeToMenuVisibleMs),
                     introStatus: snapshot.introStatus,
                     reason: snapshot.introSkipReason,
+                    degraded: snapshot.degraded === true,
                 });
             }
         },

--- a/src/ui/startup-pipeline-state-machine.js
+++ b/src/ui/startup-pipeline-state-machine.js
@@ -105,6 +105,9 @@ export class StartupPipelineStateMachine {
         this.introStatus = 'idle';
         this.introSkipReason = null;
         this.watchdogFired = false;
+        // True when the menu was forced visible in a degraded state (the watchdog
+        // fired before app readiness, so the static DOM menu is shown as a fallback).
+        this.degraded = false;
         this.history = [];
         this.disposed = false;
         this.watchdogId = null;
@@ -234,6 +237,8 @@ export class StartupPipelineStateMachine {
             appReady: this.appReadyAt !== null,
             menuReady: this.menuReadyAt !== null,
             menuVisible: this.menuVisibleAt !== null,
+            degraded: this.degraded,
+            disposed: this.disposed,
             introStatus: this.introStatus,
             introSkipReason: this.introSkipReason,
             watchdogFired: this.watchdogFired,
@@ -250,6 +255,12 @@ export class StartupPipelineStateMachine {
         if (this.disposed) return;
         this.disposed = true;
         this.clearWatchdog();
+        // Settle any pending menu-visible awaiter so a caller (e.g. bootstrap's error
+        // path, which disposes the pipeline) can never hang on waitForMenuVisible().
+        if (this.resolveMenuVisible) {
+            this.resolveMenuVisible(this.snapshot());
+            this.resolveMenuVisible = null;
+        }
     }
 
     assertStarted(event) {
@@ -276,6 +287,13 @@ export class StartupPipelineStateMachine {
         this.skipIntro('watchdog', {
             watchdogMs: this.watchdogMs,
         });
+        // The watchdog is TERMINAL: it must always leave the pipeline in a usable
+        // menu state. skipIntro's reconcile is a no-op when app readiness never
+        // arrived (menuReadyAt is null) — the exact hung-init case — so force a
+        // DEGRADED menu-visible here. Without this the ident hangs forever.
+        if (this.menuVisibleAt === null) {
+            this.markMenuVisible(true);
+        }
     }
 
     reconcileMenuVisibility() {
@@ -283,17 +301,31 @@ export class StartupPipelineStateMachine {
         if (this.menuVisibleAt !== null || this.menuReadyAt === null || !introTerminal) {
             return;
         }
+        this.markMenuVisible(false);
+    }
 
+    /**
+     * Sole writer of MENU_VISIBLE. `degraded` is true only for the watchdog fallback
+     * (app readiness never arrived); the normal reconcile path passes false.
+     */
+    markMenuVisible(degraded) {
+        if (this.menuVisibleAt !== null) {
+            return;
+        }
         this.menuVisibleAt = this.nowFn();
+        this.degraded = degraded;
         this.clearWatchdog();
         this.emit(STARTUP_PIPELINE_EVENTS.MENU_VISIBLE, {
             introStatus: this.introStatus,
             introSkipReason: this.introSkipReason,
+            degraded,
         });
         const snapshot = this.snapshot();
         this.invokeCallback(this.onMenuVisible, snapshot);
-        this.resolveMenuVisible(snapshot);
-        this.resolveMenuVisible = null;
+        if (this.resolveMenuVisible) {
+            this.resolveMenuVisible(snapshot);
+            this.resolveMenuVisible = null;
+        }
     }
 
     clearWatchdog() {

--- a/tests/unit/startup-animation-reliability.test.js
+++ b/tests/unit/startup-animation-reliability.test.js
@@ -555,28 +555,53 @@ describe('startup pipeline state machine', () => {
         expect(callbackOrder).toEqual(['dispose-visuals', 'menu-visible']);
     });
 
-    it('keeps the shell-gated menu pending when watchdog fires before app readiness', async () => {
+    it('forces a degraded menu-visible when the watchdog fires before app readiness (no hang)', async () => {
         vi.useFakeTimers();
         const { createStartupPipelineStateMachine } = await import(
             '../../src/ui/startup-pipeline-state-machine.js'
         );
-        const pipeline = createStartupPipelineStateMachine({ watchdogMs: 100 });
+        const menuVisibleDegraded = [];
+        const pipeline = createStartupPipelineStateMachine({
+            watchdogMs: 100,
+            onMenuVisible: (snap) => menuVisibleDegraded.push(snap.degraded),
+        });
         pipeline.start();
         pipeline.markIntroRunning();
 
         await vi.advanceTimersByTimeAsync(100);
+        // The watchdog is terminal: even without app readiness it forces a degraded
+        // menu-visible so the studio ident can never hang forever with no fallback.
         expect(pipeline.snapshot()).toMatchObject({
             menuReady: false,
-            menuVisible: false,
+            menuVisible: true,
+            degraded: true,
             introStatus: 'skipped',
+            introSkipReason: 'watchdog',
+            watchdogFired: true,
         });
-
-        pipeline.markAppReady();
-        pipeline.markMenuReady();
         await expect(pipeline.waitForMenuVisible()).resolves.toMatchObject({
             menuVisible: true,
+            degraded: true,
             introSkipReason: 'watchdog',
         });
+        expect(menuVisibleDegraded).toEqual([true]);
+
+        // Late app/menu readiness is a harmless no-op — the menu is already visible.
+        pipeline.markAppReady();
+        pipeline.markMenuReady();
+        expect(pipeline.snapshot().menuVisible).toBe(true);
+        expect(menuVisibleDegraded).toEqual([true]);
+    });
+
+    it('settles a pending menu-visible awaiter on dispose so callers cannot hang', async () => {
+        const { createStartupPipelineStateMachine } = await import(
+            '../../src/ui/startup-pipeline-state-machine.js'
+        );
+        const pipeline = createStartupPipelineStateMachine();
+        pipeline.start();
+        const pending = pipeline.waitForMenuVisible();
+        pipeline.dispose();
+        await expect(pending).resolves.toMatchObject({ disposed: true, menuVisible: false });
     });
 
     it('treats an explicit pre-title input as an idempotent intro skip', async () => {


### PR DESCRIPTION
## Summary

Closes the highest-risk gap from the boot review: a stalled `app.init()` could hang the studio ident forever with no fallback — the exact fragile-iGPU worst case the project guards against.

### The problem
`bootstrap()` awaited `app.init()` **raw** (no timeout, no abort signal). If init stalled, `markMenuReady()` was never reached, so `reconcileMenuVisibility()` stayed a no-op, `MENU_VISIBLE` never emitted, and `waitForMenuVisible()` hung forever. The 45s watchdog only *skipped the intro* — it never drove the readiness track — so it couldn't rescue the boot. The ident stuck on screen indefinitely with no degraded menu.

### The fix (two parts)

**1. The watchdog is now terminal** (`src/ui/startup-pipeline-state-machine.js`)
- After skipping the intro, if the menu still isn't visible (app readiness never arrived), the watchdog forces a **degraded `MENU_VISIBLE`** via a single new writer, `markMenuVisible(degraded)`. The pipeline always reaches a usable menu state.
- `dispose()` now settles any pending `waitForMenuVisible()` so an error-path teardown can't leave awaiters hanging (a latent bug the review also flagged).
- Adds a `degraded` snapshot flag, surfaced in `startup_time_to_menu_visible` telemetry.

**2. Bootstrap unblocks on the degraded menu** (`src/main.js`)
- Both app-init awaits now race against `startupPipeline.waitForMenuVisible()`. The key correctness property: **only the watchdog** forces `MENU_VISIBLE` before menu-readiness, so the race yields `null` **only** on a stalled boot. Normal boots and cinematic skips (URL flag / reduced-motion / user input) let init win, because menu-visible depends on the `markMenuReady` that runs *after* the await.
- On the degraded path `app` is null and the existing downstream fallbacks take over: the static `#start-modal` is revealed and the ident is dismissed instead of hanging.
- `appInitPromise`'s rejection is already handled by `setLoadingPromise`, so abandoning the await raises no unhandled rejection.
- Kept net-zero lines in `src/main.js` to respect the architecture line ratchet.

## Testing

- Full unit suite: **2409 passing**; architecture fitness clean; lint at baseline.
- The state-machine half is directly unit-tested — a degraded menu-visible is forced when the watchdog fires before app readiness, and `dispose()` settles a pending awaiter (`tests/unit/startup-animation-reliability.test.js`).
- The boot-flow half is reasoned through the normal / URL-skip / reduced-motion / watchdog-hang paths and covered by the existing 26-test startup suite.

## ⚠️ Verification caveat

The state-machine change is fully unit-tested, but the `src/main.js` boot-flow change could **not** be exercised against a real WebGPU/Electron boot in CI. A quick real-hardware boot smoke-check (normal boot + a forced-stall boot) is recommended before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYED438sCi9mE4mpfT1BQu)_