### PR TITLE
Derange remaining Guideline-mapped theme palettes (16 themes)

### DIFF
--- a/src/themes/astral-weave/astral-weave-tetrominos.js
+++ b/src/themes/astral-weave/astral-weave-tetrominos.js
@@ -9,13 +9,13 @@ export const ASTRAL_WEAVE_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#7deeff',
-        O: '#ffd86e',
-        T: '#ee79ff',
-        S: '#6cf9d5',
-        Z: '#ff7ccf',
-        J: '#6ca8ff',
-        L: '#ffab63',
+        I: '#ffd86e',
+        O: '#ee79ff',
+        T: '#6cf9d5',
+        S: '#ff7ccf',
+        Z: '#6ca8ff',
+        J: '#ffab63',
+        L: '#7deeff',
         GARBAGE: '#3f3f72',
     },
 

--- a/src/themes/cosmic-chimes/cosmic-chimes-tetrominos.js
+++ b/src/themes/cosmic-chimes/cosmic-chimes-tetrominos.js
@@ -12,13 +12,13 @@ export const COSMIC_CHIMES_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#8fffff', // Crystal cyan - bright chime reflection
-        O: '#ffd666', // Bell gold - warm resonant glow
-        T: '#c9a8ff', // Lavender chime - soft ethereal purple
-        S: '#6fffc4', // Mint aurora - fresh cosmic green
-        Z: '#ff8fc8', // Rose nebula - gentle pink
-        J: '#6b7fff', // Deep indigo - twilight depth
-        L: '#ffcc6b', // Warm glow - amber light
+        I: '#ffd666', // Bell gold - warm resonant glow
+        O: '#c9a8ff', // Lavender chime - soft ethereal purple
+        T: '#6fffc4', // Mint aurora - fresh cosmic green
+        S: '#ff8fc8', // Rose nebula - gentle pink
+        Z: '#6b7fff', // Deep indigo - twilight depth
+        J: '#ffcc6b', // Warm glow - amber light
+        L: '#8fffff', // Crystal cyan - bright chime reflection
         GARBAGE: '#0d1520', // Void shadow - deep space
     },
 

--- a/src/themes/crystal-cave/crystal-cave-tetrominos.js
+++ b/src/themes/crystal-cave/crystal-cave-tetrominos.js
@@ -9,13 +9,13 @@ export const CRYSTAL_CAVE_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#70f0ff', // Luminous Aquamarine
-        O: '#ffc860', // Radiant Amber Crystal
-        T: '#c080ff', // Deep Amethyst Glow
-        S: '#50ffc0', // Vibrant Emerald
-        Z: '#ff60c0', // Brilliant Rose Quartz
-        J: '#6080ff', // Deep Sapphire
-        L: '#ffa060', // Glowing Citrine
+        I: '#ffc860', // Radiant Amber Crystal
+        O: '#c080ff', // Deep Amethyst Glow
+        T: '#50ffc0', // Vibrant Emerald
+        S: '#ff60c0', // Brilliant Rose Quartz
+        Z: '#6080ff', // Deep Sapphire
+        J: '#ffa060', // Glowing Citrine
+        L: '#70f0ff', // Luminous Aquamarine
         GARBAGE: '#0a0818', // Abyssal Shadow
     },
 

--- a/src/themes/electric-dreams/electric-dreams-tetrominos.js
+++ b/src/themes/electric-dreams/electric-dreams-tetrominos.js
@@ -9,13 +9,13 @@ export const ELECTRIC_DREAMS_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#62f6ff', // Cyan electric streak
-        O: '#ffb347', // Neon amber
-        T: '#ff66f0', // Hot pink glow
-        S: '#94ffb3', // Mint pulse
-        Z: '#ff5c7c', // Coral neon
-        J: '#8a8dff', // Indigo haze
-        L: '#ffe066', // Vapor gold
+        I: '#ffb347', // Neon amber
+        O: '#ff66f0', // Hot pink glow
+        T: '#94ffb3', // Mint pulse
+        S: '#ff5c7c', // Coral neon
+        Z: '#8a8dff', // Indigo haze
+        J: '#ffe066', // Vapor gold
+        L: '#62f6ff', // Cyan electric streak
         GARBAGE: '#1b1024', // Midnight background
     },
 

--- a/src/themes/galaxy/galaxy-tetrominos.js
+++ b/src/themes/galaxy/galaxy-tetrominos.js
@@ -15,13 +15,13 @@ export const GALAXY_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#00e5ff', // Ion trail cyan - brighter, more electric
-        O: '#ffd54f', // Supernova gold - warm stellar core
-        T: '#d050ff', // Nebula violet - rich and cosmic
-        S: '#00ffc8', // Aurora teal - ethereal glow
-        Z: '#ff4da6', // Solar flare magenta - hot pink energy
-        J: '#6366f1', // Deep space indigo - mysterious depth
-        L: '#ff8a50', // Comet ember - trailing warmth
+        I: '#ffd54f', // Supernova gold - warm stellar core
+        O: '#d050ff', // Nebula violet - rich and cosmic
+        T: '#00ffc8', // Aurora teal - ethereal glow
+        S: '#ff4da6', // Solar flare magenta - hot pink energy
+        Z: '#6366f1', // Deep space indigo - mysterious depth
+        J: '#ff8a50', // Comet ember - trailing warmth
+        L: '#00e5ff', // Ion trail cyan - brighter, more electric
         GARBAGE: '#0a0015', // Interstellar void - near black with hint of purple
     },
 

--- a/src/themes/geode/geode-tetrominos.js
+++ b/src/themes/geode/geode-tetrominos.js
@@ -10,13 +10,13 @@ export const GEODE_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#60ffff', // Cosmic Teal
-        O: '#ffd060', // Solar Gold
-        T: '#e060ff', // Nebula Magenta
-        S: '#60ff90', // Aurora Green
-        Z: '#ff6040', // Ember Orange
-        J: '#ff70ff', // Starlight Pink
-        L: '#ffa050', // Supernova Amber
+        I: '#ffd060', // Solar Gold
+        O: '#e060ff', // Nebula Magenta
+        T: '#60ff90', // Aurora Green
+        S: '#ff6040', // Ember Orange
+        Z: '#ff70ff', // Starlight Pink
+        J: '#ffa050', // Supernova Amber
+        L: '#60ffff', // Cosmic Teal
         GARBAGE: '#0a0608', // Void Shadow
     },
 

--- a/src/themes/himalayan-peak/himalayan-peak-tetrominos.js
+++ b/src/themes/himalayan-peak/himalayan-peak-tetrominos.js
@@ -9,13 +9,13 @@ export const HIMALAYAN_PEAK_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#00a8ff', // Prayer flag blue - sky and space
-        O: '#f0f5ff', // Snow cap white - pristine peak snow
-        T: '#9c88ff', // Prayer flag purple - spiritual wisdom
-        S: '#4cd137', // Prayer flag green - nature and harmony
-        Z: '#e84118', // Prayer flag red - life force and bravery
-        J: '#5a7090', // Deep mountain gray - shadowed peaks
-        L: '#fbc531', // Prayer flag yellow - earth and enlightenment
+        I: '#f0f5ff', // Snow cap white - pristine peak snow
+        O: '#9c88ff', // Prayer flag purple - spiritual wisdom
+        T: '#4cd137', // Prayer flag green - nature and harmony
+        S: '#e84118', // Prayer flag red - life force and bravery
+        Z: '#5a7090', // Deep mountain gray - shadowed peaks
+        J: '#fbc531', // Prayer flag yellow - earth and enlightenment
+        L: '#00a8ff', // Prayer flag blue - sky and space
         GARBAGE: '#3c465a', // Mountain shadow - deep rocky depths
     },
 

--- a/src/themes/koi-pond/koi-pond-tetrominos.js
+++ b/src/themes/koi-pond/koi-pond-tetrominos.js
@@ -14,13 +14,13 @@ export const KOI_POND_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#7eeeff', // Crystal pond cyan - clearer, more vibrant
-        O: '#ffc852', // Lantern gold - warm amber glow
-        T: '#ffadd2', // Blossom pink - soft sakura
-        S: '#7dffb8', // Lily pad green - fresh and bright
-        Z: '#ff7b52', // Koi orange - vivid scales
-        J: '#7b94ff', // Twilight indigo - evening reflection
-        L: '#ffe48a', // Candle glow - soft warm light
+        I: '#ffc852', // Lantern gold - warm amber glow
+        O: '#ffadd2', // Blossom pink - soft sakura
+        T: '#7dffb8', // Lily pad green - fresh and bright
+        S: '#ff7b52', // Koi orange - vivid scales
+        Z: '#7b94ff', // Twilight indigo - evening reflection
+        J: '#ffe48a', // Candle glow - soft warm light
+        L: '#7eeeff', // Crystal pond cyan - clearer, more vibrant
         GARBAGE: '#0f1f1a', // Deep pond shadow
     },
 

--- a/src/themes/lunara/lunara-tetrominos.js
+++ b/src/themes/lunara/lunara-tetrominos.js
@@ -8,13 +8,13 @@ export const LUNARA_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#a8e0ff', // Brilliant Moonlit Glacier
-        O: '#ffd4a8', // Warm Lantern Amber
-        T: '#d8a8ff', // Vivid Amethyst Glow
-        S: '#a8ffe8', // Bright Aurora Teal
-        Z: '#ffa8d0', // Vibrant Alpine Rose
-        J: '#8090e0', // Deep Twilight Indigo
-        L: '#ffc050', // Radiant Sunrise Gold
+        I: '#ffd4a8', // Warm Lantern Amber
+        O: '#d8a8ff', // Vivid Amethyst Glow
+        T: '#a8ffe8', // Bright Aurora Teal
+        S: '#ffa8d0', // Vibrant Alpine Rose
+        Z: '#8090e0', // Deep Twilight Indigo
+        J: '#ffc050', // Radiant Sunrise Gold
+        L: '#a8e0ff', // Brilliant Moonlit Glacier
         GARBAGE: '#252840', // Deep Mountain Shadow
     },
 

--- a/src/themes/misty-lake/misty-lake-tetrominos.js
+++ b/src/themes/misty-lake/misty-lake-tetrominos.js
@@ -9,13 +9,13 @@ export const MISTY_LAKE_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#b1e5ff', // Misty cyan
-        O: '#ffd59a', // Lantern amber
-        T: '#cfc2ff', // Lilac glow
-        S: '#9efad2', // Dewy mint
-        Z: '#ffa9c4', // Petal pink
-        J: '#7a92d5', // Twilight indigo
-        L: '#ffe388', // Warm sunrise
+        I: '#ffd59a', // Lantern amber
+        O: '#cfc2ff', // Lilac glow
+        T: '#9efad2', // Dewy mint
+        S: '#ffa9c4', // Petal pink
+        Z: '#7a92d5', // Twilight indigo
+        J: '#ffe388', // Warm sunrise
+        L: '#b1e5ff', // Misty cyan
         GARBAGE: '#131c2d', // Lake shadow
     },
 

--- a/src/themes/moonlit-greenhouse/moonlit-greenhouse-tetrominos.js
+++ b/src/themes/moonlit-greenhouse/moonlit-greenhouse-tetrominos.js
@@ -8,13 +8,13 @@ export const MOONLIT_GREENHOUSE_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#a8ffd8', // Dewdrop mint
-        O: '#ffda9e', // Lantern glow
-        T: '#d7b3ff', // Lavender bloom
-        S: '#82f5b8', // Lush leaf
-        Z: '#ff9ecf', // Petal pink
-        J: '#5b7ba7', // Night indigo
-        L: '#ffd76a', // Warm candlelight
+        I: '#ffda9e', // Lantern glow
+        O: '#d7b3ff', // Lavender bloom
+        T: '#82f5b8', // Lush leaf
+        S: '#ff9ecf', // Petal pink
+        Z: '#5b7ba7', // Night indigo
+        J: '#ffd76a', // Warm candlelight
+        L: '#a8ffd8', // Dewdrop mint
         GARBAGE: '#112021', // Greenhouse silhouette
     },
 

--- a/src/themes/moonrise-summit/moonrise-summit-tetrominos.js
+++ b/src/themes/moonrise-summit/moonrise-summit-tetrominos.js
@@ -9,13 +9,13 @@ export const MOONRISE_SUMMIT_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#bfe9ff', // Glacier blue
-        O: '#ffe7b3', // Warm lantern glow
-        T: '#c9b2ff', // Lavender dusk
-        S: '#d3fff1', // Misty teal
-        Z: '#ffb0c9', // Alpine rose pink
-        J: '#8aa4d5', // Twilight indigo
-        L: '#ffd089', // Summit sunrise
+        I: '#ffe7b3', // Warm lantern glow
+        O: '#c9b2ff', // Lavender dusk
+        T: '#d3fff1', // Misty teal
+        S: '#ffb0c9', // Alpine rose pink
+        Z: '#8aa4d5', // Twilight indigo
+        J: '#ffd089', // Summit sunrise
+        L: '#bfe9ff', // Glacier blue
         GARBAGE: '#1b1f33', // Mountain shadow
     },
 

--- a/src/themes/rainy-window/rainy-window-tetrominos.js
+++ b/src/themes/rainy-window/rainy-window-tetrominos.js
@@ -8,13 +8,13 @@ export const RAINY_WINDOW_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#8ccff9', // Rain haze
-        O: '#f6c46a', // Streetlight glow
-        T: '#c9b4ff', // Lavender neon
-        S: '#7bf0d0', // Mint reflections
-        Z: '#ff8fb5', // Umbrella pink
-        J: '#586abf', // Midnight indigo
-        L: '#ffe9b7', // Window light
+        I: '#f6c46a', // Streetlight glow
+        O: '#c9b4ff', // Lavender neon
+        T: '#7bf0d0', // Mint reflections
+        S: '#ff8fb5', // Umbrella pink
+        Z: '#586abf', // Midnight indigo
+        J: '#ffe9b7', // Window light
+        L: '#8ccff9', // Rain haze
         GARBAGE: '#0b131d', // Storm shadow
     },
 

--- a/src/themes/shifting-sands/shifting-sands-tetrominos.js
+++ b/src/themes/shifting-sands/shifting-sands-tetrominos.js
@@ -12,13 +12,13 @@ export const SHIFTING_SANDS_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#7ec8ff', // Moonlit oasis - soft blue water
-        O: '#ffd06a', // Lantern gold - warm amber glow
-        T: '#c9a0ff', // Twilight purple - desert dusk
-        S: '#7fffb8', // Desert mint - cool oasis green
-        Z: '#ff9070', // Sunset coral - warm horizon
-        J: '#8090ff', // Night sky indigo - deep blue
-        L: '#ffb855', // Firefly amber - glowing orange
+        I: '#ffd06a', // Lantern gold - warm amber glow
+        O: '#c9a0ff', // Twilight purple - desert dusk
+        T: '#7fffb8', // Desert mint - cool oasis green
+        S: '#ff9070', // Sunset coral - warm horizon
+        Z: '#8090ff', // Night sky indigo - deep blue
+        J: '#ffb855', // Firefly amber - glowing orange
+        L: '#7ec8ff', // Moonlit oasis - soft blue water
         GARBAGE: '#1a1528', // Desert shadow - deep night
     },
 

--- a/src/themes/singing-bowl/singing-bowl-tetrominos.js
+++ b/src/themes/singing-bowl/singing-bowl-tetrominos.js
@@ -11,13 +11,13 @@ export const SINGING_BOWL_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#b5fff2', // Soft aqua - like clear water in the bowl
-        O: '#fdda9b', // Brass glow - reflecting the bowl itself
-        T: '#e5b6ff', // Lavender incense - rising smoke
-        S: '#a9ffd0', // Lotus leaf - fresh green tranquility
-        Z: '#ff9fbf', // Rose petal - gentle warmth
-        J: '#8d99ff', // Indigo chant - deep meditation
-        L: '#ffe8aa', // Candlelight - warm golden flicker
+        I: '#fdda9b', // Brass glow - reflecting the bowl itself
+        O: '#e5b6ff', // Lavender incense - rising smoke
+        T: '#a9ffd0', // Lotus leaf - fresh green tranquility
+        S: '#ff9fbf', // Rose petal - gentle warmth
+        Z: '#8d99ff', // Indigo chant - deep meditation
+        J: '#ffe8aa', // Candlelight - warm golden flicker
+        L: '#b5fff2', // Soft aqua - like clear water in the bowl
         GARBAGE: '#1a1a21', // Meditation shadow - deep void
     },
 

--- a/src/themes/swedish-forest/swedish-forest-tetrominos.js
+++ b/src/themes/swedish-forest/swedish-forest-tetrominos.js
@@ -8,13 +8,13 @@ export const SWEDISH_FOREST_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#9be8ff', // Misty cyan
-        O: '#ffd27a', // Lantern amber
-        T: '#c7b5ff', // Twilight lavender
-        S: '#7ff4c9', // Mossy mint
-        Z: '#ff9fc0', // Aurora rose
-        J: '#6479d8', // Pine indigo
-        L: '#ffe8a6', // Dawn glow
+        I: '#ffd27a', // Lantern amber
+        O: '#c7b5ff', // Twilight lavender
+        T: '#7ff4c9', // Mossy mint
+        S: '#ff9fc0', // Aurora rose
+        Z: '#6479d8', // Pine indigo
+        J: '#ffe8a6', // Dawn glow
+        L: '#9be8ff', // Misty cyan
         GARBAGE: '#121b27', // Forest shadow
     },
 

--- a/src/themes/tornado/tornado-tetrominos.js
+++ b/src/themes/tornado/tornado-tetrominos.js
@@ -8,13 +8,13 @@ export const TORNADO_TETROMINOS = {
     version: 1,
 
     colors: {
-        I: '#87CEEB', // Cool contrast
-        O: '#FFD700', // Bright gold
-        T: '#E6A8D7', // Soft accent
-        S: '#98FB98', // Fresh green
-        Z: '#FFB7C5', // Warm pink
-        J: '#9DC8E8', // Light blue
-        L: '#FFCC5C', // Warm amber
+        I: '#FFD700', // Bright gold
+        O: '#E6A8D7', // Soft accent
+        T: '#98FB98', // Fresh green
+        S: '#FFB7C5', // Warm pink
+        Z: '#9DC8E8', // Light blue
+        J: '#FFCC5C', // Warm amber
+        L: '#87CEEB', // Cool contrast
         GARBAGE: '#4a6741', // Deep neutral
     },
 


### PR DESCRIPTION
## Summary

Completes the trade-dress palette work from the v3.0 review (Finding PAL-1 / §8): the remaining themes that reproduced the Tetris **Guideline color-to-shape mapping** (I=cyan, O=yellow, T=purple, S=green, Z=red, J=blue, L=orange) are re-mapped so **no piece keeps its Guideline colour**.

Method: each theme's own 7 colours are **rotated by one shape** — this preserves each theme's exact palette, mood, and designer-balanced contrast, and only breaks the shape→colour pairing. (Same approach used for the first 6 themes earlier.)

## Themes changed (17)
- **Fully matched the mapping (10):** `astral-weave`, `cosmic-chimes`, `crystal-cave`, `electric-dreams`, `misty-lake`, `moonrise-summit`, `shifting-sands`, `singing-bowl`, `swedish-forest`, `tornado`.
- **Near-full (6):** `galaxy`, `geode`, `himalayan-peak`, `koi-pond`, `lunara`, `moonlit-greenhouse`.
- **Dormant config (1):** `rainy-window` — deranged so it's safe if ever wired up.

## Verification
- All 17 `*-tetrominos.js` files pass `node --check`.
- No theme has a hidden second piece-colour map to sync (checked; only `neon-dusk` had one, already handled previously).
- Confirmed no piece retains a Guideline primary.

## Impact
Piece colours only — **no gameplay or logic change**, but it *is* a visual change. A quick in-game look is worth doing when convenient (the app couldn't be launched in this environment). Combined with the earlier 6, this means **no shipped theme reproduces the Tetris colour mapping**.

## Still open (not in this PR)
Startup/menu tetromino branding; the legacy-canvas grid fallback; ensuring the packaged build ships `CREDITS.md`; and counsel review before commercial launch. The review also suggests a CI gate that fails the build if any theme ever slips back into the full Guideline mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgZdPRwPc3sStraAtB94QL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgZdPRwPc3sStraAtB94QL)_