### PR TITLE
Ship CREDITS.md in web + Electron builds (GEN-4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
     ],
     "extraResources": [
       {
+        "from": "CREDITS.md",
+        "to": "CREDITS.md"
+      },
+      {
         "from": "node_modules/steamworks.js",
         "to": "native_modules/steamworks.js",
         "filter": [

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite';
 import replace from '@rollup/plugin-replace';
 import path from 'path';
-import { realpathSync } from 'node:fs';
+import { realpathSync, copyFileSync, existsSync } from 'node:fs';
 import { createThemeThumbnailAssetPlugin } from './scripts/theme-thumbnail-assets.js';
 
 // Resolve the project root to its real on-disk casing (canonical uppercase drive
@@ -29,6 +29,21 @@ export default defineConfig({
     createThemeThumbnailAssetPlugin({
       projectRoot,
     }),
+    // Copy top-level legal/credit notices into the build output so they ship with
+    // both the web build (dist → GitHub Pages) and the Electron build (which packs
+    // dist/**/*). Required so third-party attributions (CC-BY, the SynthCity MIT
+    // notice, etc.) actually reach end users.
+    {
+      name: 'copy-legal-notices',
+      apply: 'build',
+      closeBundle() {
+        for (const file of ['CREDITS.md', 'README.md']) {
+          const src = path.resolve(projectRoot, file);
+          const dest = path.resolve(projectRoot, 'dist', file);
+          if (existsSync(src)) copyFileSync(src, dest);
+        }
+      },
+    },
   ],
 
   // Server configuration


### PR DESCRIPTION
## Summary

Fixes review finding **GEN-4** — the build didn't include `CREDITS.md`, so third-party attributions (CC-BY assets, the SynthCity MIT notice, music provenance) never reached end users. Several of those (MIT/CC-BY) legally require the notice to be included in distributions.

## Changes
- **`vite.config.js`** — adds a build-only `copy-legal-notices` plugin that copies `CREDITS.md` (and `README.md`) into `dist/` on `vite build`. This covers the **web/GitHub-Pages** build and the **Electron** package (which packs `dist/**`).
- **`package.json`** — adds `CREDITS.md` to electron-builder `extraResources`, so the installed desktop app also carries it at the conventional `resources/CREDITS.md` location (belt-and-suspenders, independent of `dist`).

## Verification
- `vite.config.js` passes `node --check`; `package.json` is valid JSON with `CREDITS.md` present in `extraResources`.
- The `closeBundle` copy logic was exercised against a temp output dir — both files copy successfully.
- (Full `vite build` / `electron-builder` not run here — no `node_modules` in this environment.)

## Note
This makes the credits **file** ship with the build (the license-compliance requirement). A user-facing in-app **Credits/Legal screen** that displays it is a separate, nice-to-have follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgZdPRwPc3sStraAtB94QL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgZdPRwPc3sStraAtB94QL)_