### PR TITLE
Rename 'Quadra Ace' bot skill tier to neutral 'Ace'

### DIFF
--- a/src/ui/local-match-config-modal.js
+++ b/src/ui/local-match-config-modal.js
@@ -17,7 +17,7 @@ import { TEAM_COLORS } from '../core/multi-player-state.js';
 
 const BOT_SKILL_TIERS = [
     'Rookie', 'Novice', 'Learner', 'Steady', 'Skilled',
-    'Sharp', 'Expert', 'Master', 'Quadra Ace', 'Machine',
+    'Sharp', 'Expert', 'Master', 'Ace', 'Machine',
 ];
 const DEFAULT_BOT_SKILL = 5;
 


### PR DESCRIPTION
## Summary

The local-multiplayer bot skill titles (Levels 1–10) were mostly generic, but **Level 9 was "Quadra Ace"** — a player-visible use of the third-party game name *Quadra*. Renamed to **"Ace"**.

Full list now: Rookie · Novice · Learner · Steady · Skilled · Sharp · Expert · Master · **Ace** · Machine — all generic.

## Notes
- `bot-difficulty.js` tiers already use plain "Level 1"–"Level 10" (no change needed).
- The online match-config modal has no such name list.
- No test referenced "Quadra Ace"; file passes `node --check`. UI-string only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgZdPRwPc3sStraAtB94QL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgZdPRwPc3sStraAtB94QL)_